### PR TITLE
Add support for directory selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This action lints Markdown files using [`write-good`](https://github.com/btford/write-good) and prints the output to the log.
 
+## Inputs
+
+### `directory`
+
+Select a directory containing files to evaluate with `write-good`. The default is ".", the current working directory.
+
 ## Outputs
 
 ### `result`
@@ -14,7 +20,7 @@ Use with [`add-pr-comment`](https://github.com/marketplace/actions/add-pr-commen
 
 ## Example usage
 
-```
+```yaml
 on:
   push:
     branches:
@@ -46,4 +52,3 @@ jobs:
         repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
         allow-repeats: false # This is the default
 ```
-

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This action lints Markdown files using [`write-good`](https://github.com/btford/
 
 ### `directory`
 
-Select a directory containing files to evaluate with `write-good`. The default is ".", the current working directory.
+*(Optional)* Select a directory containing files to examine with `write-good`. The default is ".", the current working directory.
 
 ## Outputs
 
@@ -38,7 +38,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: write-good action step
       id: write-good
-      uses: tomwhross/write-good-action@v1.3
+      uses: tomwhross/write-good-action@v1.4
+      # with:
+      #   directory: "manuscript" # Optional, uncomment to specify a directory to scan
     # Use the output from the `write-good` step
     - name: Get the write-good output
       run: echo "${{ steps.write-good.outputs.result }}"

--- a/action.yml
+++ b/action.yml
@@ -2,12 +2,18 @@
 name: 'Lint Markdown'
 description: 'Lint Markdown files using write-good'
 branding:
-  icon: 'check'  
+  icon: 'check'
   color: 'green'
+inputs:
+  directory: 
+    description: 'Name of Directory to scan with write-good [default is "."]'
+    required: false
+    default: '.'
 outputs:
   result: # id of output
     description: 'Linter suggestions'
 runs:
   using: 'docker'
   image: 'Dockerfile'
-
+  args:
+    - ${{ inputs.directory }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -l
 
 # lint markdown files and capture output
-result=$(find . -name "*.md" | xargs npx write-good | sed -e $'s/In .\//\\\n\\\nIn .\//g' | tail -n +3)
+result=$(find $1 -name "*.md" | xargs npx write-good | sed -e $'s/In .\//\\\n\\\nIn .\//g' | tail -n +3)
 
 if [ -z "$result" ]; then
 	echo "No warnings from write-good"


### PR DESCRIPTION
Adds the option to select a directory to execute `write-good` on. Default behavior is still to use `'.'`, the current working directory.

Users will simply need to add the `with` directive and specify a directory as a string. If they do not add this, it will persist with the current default behavior, so this is not technically a breaking change.  As such you might be able to just go to v1.3. I have tested this against several private repositories of mine and haven't found any issues yet.

The main use case for this is to exclude un-editable files (such as LICENSE.md files) that contain false positives for `write-good`. In this case, I'm specifying a specific `manuscript` directory for a book that contains all of the markdown for the book and don't need to lint anything except those files.

Example usage:

```yaml
  # Use "write-good" to check for poorly worded writing
  write_good:
    runs-on: ubuntu-latest
    name: write-good
    steps:
    - uses: actions/checkout@v2
    - name: write-good action step
      id: write-good
      uses: lykinsbd/write-good-action@main
      with:
        directory: "manuscript"
    # Use the output from the `write-good` step
    - name: Get the write-good output
      run: echo "${{ steps.write-good.outputs.result }}"
    - name: Post comment
      uses: mshick/add-pr-comment@v1
      if: ${{ steps.write-good.outputs.result }}
      with:
        message: |
          ${{ steps.write-good.outputs.result }}
        repo-token: ${{ secrets.GITHUB_TOKEN }}
        repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
        allow-repeats: false # This is the default
```

Please let me know if you have any questions, or if I need to make any changes!