### PR TITLE
Prevent command execution by substituting ` for '

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,9 @@ fi
 
 header=$'Here are some friendly prose warnings from [`write-good`](https://github.com/btford/write-good):\n'
 
+# prevent command execution by substituting ` for '
+result=$(echo "$result" | sed "s/\`/'/g")
+
 result=$header$'```\n'$result$'\n```'
 
 # add support for multiline output


### PR DESCRIPTION
Situation:
Words enclosed in backticks are run as commands.

For example, the current behavior when run on `file.md`

```md
Lorem ipsum `dolor` dolor sit amet

Lorem ipsum `host` dolor sit amet
```

creates the output 

```
/home/runner/work/_temp/62c5724b-6e8d-41c5-8f23-3504379a521e.sh: line 17: dolor: command not found
Usage: host [-aCdilrTvVw] [-c class] [-N ndots] [-t type] [-W time]
            [-R number] [-m flag] hostname [server]
       -a is equivalent to -v -t ANY
       -A is like -a but omits RRSIG, NSEC, NSEC3
       -c specifies query class for non-IN data
       -C compares SOA records on authoritative nameservers
       -d is equivalent to -v
       -l lists all hosts in a domain, using AXFR
       -m set memory debugging flag (trace|record|usage)
       -N changes the number of dots allowed before root lookup is done
       -r disables recursive processing
       -R specifies number of retries for UDP packets
       -s a SERVFAIL response should stop query
       -t specifies the query type
       -T enables TCP/IP mode
       -U enables UDP mode
       -v enables verbose output
       -V print version number and exit
       -w specifies to wait forever for a reply
       -W specifies how long to wait for a reply
       -4 use IPv4 query transport only
       -6 use IPv6 query transport only
```

along with other confusing output from other files like

```
/home/runner/work/_temp/62c5724b-6e8d-41c5-8f23-3504379a521e.sh: line 239: ^^^: command not found
/home/runner/work/_temp/62c5724b-6e8d-41c5-8f23-3504379a521e.sh: line 240: and: command not found
/home/runner/work/_temp/62c5724b-6e8d-41c5-8f23-3504379a521e.sh: line 241: -------------: command not found
/home/runner/work/_temp/62c5724b-6e8d-41c5-8f23-3504379a521e.sh: line 242: y: command not found
/home/runner/work/_temp/62c5724b-6e8d-41c5-8f23-3504379a521e.sh: line 243: ^^^^^^^^^: command not found
```

